### PR TITLE
nix(package): change identifier visibility

### DIFF
--- a/nbuild-core/src/models/nix.rs
+++ b/nbuild-core/src/models/nix.rs
@@ -299,7 +299,7 @@ in
     }
 
     /// Helper to get a deterministic identifier for a package
-    fn identifier(&self) -> String {
+    pub fn identifier(&self) -> String {
         format!(
             "{}_{}",
             self.name,


### PR DESCRIPTION
## Description

My LSP reports an error because:
<img width="1800" alt="Screenshot 2023-06-19 at 17 23 00" src="https://github.com/shuttle-hq/cargo-nbuild/assets/14218860/053293fd-9c42-4b13-8510-e27a9ba552a9">

I assumed it should be `identifier()` instead because there is no such `name()` method:
<img width="1800" alt="Screenshot 2023-06-19 at 17 23 31" src="https://github.com/shuttle-hq/cargo-nbuild/assets/14218860/677491b0-9de3-48bc-9e0e-a6d40c501057">
