### PR TITLE
Add workspace support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,65 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytes"
@@ -39,6 +94,7 @@ dependencies = [
 name = "cargo-nbuild"
 version = "0.1.2"
 dependencies = [
+ "clap",
  "nbuild-core",
  "tokio",
  "tracing",
@@ -69,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-expr"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +147,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +209,27 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -122,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +266,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "idna"
@@ -151,6 +294,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +333,12 @@ name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -232,7 +404,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -330,6 +502,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "rustix"
+version = "0.37.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +593,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -647,6 +839,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/nbuild-core/src/lib.rs
+++ b/nbuild-core/src/lib.rs
@@ -15,4 +15,7 @@ pub enum Error {
 
     #[error("failed to read cargo lock file: {0}")]
     LockFile(#[from] cargo_lock::Error),
+
+    #[error("in a workspace root, need to select a package from: {}", .0.join(", "))]
+    NeedToSelectPackage(Vec<String>),
 }

--- a/nbuild-core/src/models/cargo/mod.rs
+++ b/nbuild-core/src/models/cargo/mod.rs
@@ -95,25 +95,37 @@ impl Package {
             })
         }));
 
-        let root_id = metadata
+        let resolved = metadata
             .resolve
             .as_ref()
-            .expect("metadata to have a resolve section")
-            .root
-            .as_ref()
-            .expect("a root from metadata")
-            .clone();
+            .expect("metadata to have a resolve section");
 
-        let mut resolved_packages = Default::default();
+        match resolved.root {
+            None => {
+                let available_packages = metadata
+                    .workspace_packages()
+                    .iter()
+                    .map(|p| p.name.clone())
+                    .collect();
+                Err(Error::NeedToSelectPackage(available_packages))
+            }
+            Some(ref root_id) => {
+                let mut resolved_packages = Default::default();
 
-        Ok(Self::get_package(
-            root_id,
-            &packages,
-            &nodes,
-            &checksums,
-            &mut resolved_packages,
-            &platform,
-        ))
+                Ok(Self::get_package(
+                    root_id.clone(),
+                    &packages,
+                    &nodes,
+                    &checksums,
+                    &mut resolved_packages,
+                    &platform,
+                ))
+            }
+        }
+        // let root_id =             .root
+        //     .as_ref()
+        //     .expect("a root from metadata")
+        //     .clone();
     }
 
     /// Recursively get a package and its dependencies. Use the `resolved_packages` to make sure we only

--- a/nbuild-core/src/models/cargo/mod.rs
+++ b/nbuild-core/src/models/cargo/mod.rs
@@ -414,6 +414,7 @@ mod tests {
     use std::{cell::RefCell, collections::HashMap, path::PathBuf, str::FromStr};
 
     use crate::models::cargo::{Dependency, Package};
+    use crate::Error;
 
     use pretty_assertions::assert_eq;
 
@@ -424,7 +425,7 @@ mod tests {
             .join("tests")
             .join("simple");
 
-        let package = Package::from_current_dir(path.clone()).unwrap();
+        let package = Package::from_current_dir(path.clone(), None).unwrap();
 
         assert_eq!(
             package,
@@ -502,16 +503,12 @@ mod tests {
             .unwrap()
             .join("tests")
             .join("workspace");
-        let path = workspace.join("parent");
 
-        let package = Package::from_current_dir(path.clone()).unwrap();
-
-        assert_eq!(
-            package,
+        let package_expected =
             Package {
                 name: "parent".to_string(),
                 version: "0.1.0".parse().unwrap(),
-                source: path.into(),
+                source: workspace.join("parent").into(),
                 lib_name: None,
                 lib_path: None,
                 build_path: None,
@@ -769,7 +766,16 @@ mod tests {
                 features: Default::default(),
                 enabled_features: Default::default(),
                 edition: "2021".to_string(),
-            }
+            };
+
+        assert!(matches!(
+            Package::from_current_dir(workspace.clone(), None).unwrap_err(),
+            Error::NeedToSelectPackage(_)
+        ));
+
+        assert_eq!(
+            Package::from_current_dir(workspace.clone(), Some("parent".to_string())).unwrap(),
+            package_expected
         );
     }
 }

--- a/nbuild/Cargo.toml
+++ b/nbuild/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.3.5", features = ["env", "derive"] }
 nbuild-core = { path = "../nbuild-core", version = "0.1.0" }
 tokio = { version = "1.28.1", features = ["io-util", "macros", "process", "rt-multi-thread"] }
 tracing = { workspace = true }


### PR DESCRIPTION
This adds a `--package` option to be able to select which package to build instead of panicking. In case the option isn't given in a workspace, an error is returned, but like the other ones it isn't printed formatted.

I've added clap for arg parsing because the `shuttle` app also uses it, but if you prefer to use something else I'm happy to make the change !

Fixes #5.